### PR TITLE
Update lxml 6.0.1

### DIFF
--- a/custom_components/predistribuce/manifest.json
+++ b/custom_components/predistribuce/manifest.json
@@ -6,5 +6,5 @@
     "dependencies": [],
     "codeowners": ["@slesinger"],
     "version": "1.0.1",
-    "requirements": ["lxml==5.3.0"]
-}
+    "requirements": ["lxml==6.0.1"]
+}


### PR DESCRIPTION
This PR updates the lxml dependency to version 6.0.1.

The update resolves Issue #27.
Thanks to the issue author @Plawasan for describing the solution.